### PR TITLE
Fix: Cache invalidation now properly deletes SoT data

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
@@ -153,6 +153,7 @@ class RealReadStore<
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
             memory.remove(key)
             sot.clearCache(key)
+            sot.delete(key)
         }
     }
 

--- a/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
+++ b/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
@@ -245,6 +245,28 @@ class RealReadStoreTest {
     }
 
     @Test
+    fun invalidate_givenKey_thenDeletesFromSOT() = runTest {
+        // Given
+        val sot = FakeSourceOfTruth<StoreKey, TestUser>()
+        sot.emit(TEST_KEY_1, TEST_USER_1)
+        val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)
+        memory.put(TEST_KEY_1, TEST_USER_1)
+        val store = createStore(scope = backgroundScope, memory = memory, sot = sot)
+
+        // When
+        store.invalidate(TEST_KEY_1)
+        advanceUntilIdle()
+
+        // Then - memory cleared
+        assertNull(memory.get(TEST_KEY_1))
+        // And SoT data deleted
+        assertEquals(1, sot.deletes.size)
+        assertEquals(TEST_KEY_1, sot.deletes.first())
+        // Verify data is actually gone from SoT
+        assertNull(sot.getData(TEST_KEY_1))
+    }
+
+    @Test
     fun invalidateNamespace_thenClearsMemory() = runTest {
         // Given
         val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)


### PR DESCRIPTION
## Summary
- Fixed the `invalidate()` method to properly delete stale data from the Source of Truth
- Added test to verify SoT data is deleted on invalidation
- Ensures fresh data is fetched on next read after invalidation

## Problem
The `invalidate` method was calling `sot.clearCache(key)` which has a default no-op implementation. This meant custom SourceOfTruth implementations wouldn't clear their underlying cache, leaving stale data in the SoT that could be served on next access, breaking the expectation of fresh data.

## Solution
Now `invalidate()` calls `sot.delete(key)` to remove the persisted data from the SoT. This ensures that:
1. Memory cache is cleared
2. SoT persisted data is deleted
3. On next read, there's no stale data, forcing a fresh fetch from the network

## Test Plan
- [x] Added new test `invalidate_givenKey_thenDeletesFromSOT` that verifies:
  - Memory cache is cleared
  - SoT delete method is called
  - Data is actually removed from SoT
- [x] All existing tests pass

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Invalidate now removes data from SoT via `sot.delete(key)` and adds a test verifying deletion alongside memory cache clearing.
> 
> - **Core**:
>   - `RealReadStore.invalidate(key)`: after clearing memory and `sot.clearCache(key)`, now calls `sot.delete(key)` to remove persisted SoT data.
> - **Tests**:
>   - Add `invalidate_givenKey_thenDeletesFromSOT` verifying memory is cleared, `sot.delete` is invoked, and SoT data is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b831ed179fbc39866d6a5b3724d04bd034a0d180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->