### PR TITLE
Fix SchemaRegistry adapter lookup for custom type names

### DIFF
--- a/normalization/runtime/src/commonTest/kotlin/dev/mattramotar/storex/normalization/schema/SchemaRegistryTest.kt
+++ b/normalization/runtime/src/commonTest/kotlin/dev/mattramotar/storex/normalization/schema/SchemaRegistryTest.kt
@@ -1,0 +1,43 @@
+package dev.mattramotar.storex.normalization.schema
+
+import dev.mattramotar.storex.normalization.format.NormalizedRecord
+import dev.mattramotar.storex.normalization.format.NormalizedValue
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+class SchemaRegistryTest {
+    private data class CustomEntity(val id: String)
+
+    private object CustomEntityAdapter : EntityAdapter<CustomEntity> {
+        override val typeName: String = "CanonicalCustomEntity"
+
+        override fun extractId(entity: CustomEntity): String = entity.id
+
+        override fun normalize(
+            entity: CustomEntity,
+            ctx: NormalizationContext,
+        ): Pair<NormalizedRecord, Set<String>> =
+            mapOf("id" to NormalizedValue.Scalar(entity.id)) to setOf("id")
+
+        override suspend fun denormalize(
+            record: NormalizedRecord,
+            ctx: DenormalizationContext,
+        ): CustomEntity {
+            val scalar = record["id"] as? NormalizedValue.Scalar
+                ?: error("Missing id field")
+            return CustomEntity(id = scalar.value as String)
+        }
+    }
+
+    @Test
+    fun getAdapterByClass_respectsCustomTypeName() {
+        val registry = SchemaRegistry(
+            byType = mapOf(CustomEntityAdapter.typeName to CustomEntityAdapter),
+            byClass = mapOf(CustomEntity::class to CustomEntityAdapter),
+        )
+
+        val adapter = registry.getAdapter(CustomEntity::class)
+
+        assertSame(CustomEntityAdapter, adapter)
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the schema registry can resolve entity adapters by `KClass` when a `@Normalizable` overrides its type name
- teach the KSP processor to register adapters keyed by their concrete entity classes
- cover the regression with a unit test for `SchemaRegistry.getAdapter(KClass)`

## Testing
- `./gradlew :normalization:runtime:check` *(fails: missing JDK 17 toolchain in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea3a5a1d38832b869e7b251bdb256f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> SchemaRegistry now resolves adapters by KClass using a new byClass map, and the KSP processor generates and registers class-to-adapter mappings; adds a unit test.
> 
> - **Runtime**:
>   - `SchemaRegistry`: add `byClass: Map<KClass<*>, EntityAdapter<*>>`; `getAdapter(KClass)` queries `byClass` then falls back to `byType` or errors.
> - **KSP**:
>   - Track entity class in `entityAdapters` and generate a class-to-adapter map in `SchemaRegistry_Generated` (pass both maps to superclass).
> - **Tests**:
>   - `SchemaRegistryTest`: verifies `getAdapter(KClass)` works with custom `typeName`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78d1673c040d86160f8531494c6df38b3ed50497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->