### PR TITLE
Honor stale-if-error window when emitting stale errors

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
@@ -65,7 +65,8 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
         val cache = createMemoryCache()
         val sot = createSourceOfTruth()
         val converter = createConverter()
-        val validator = createFreshnessValidator()
+        val freshness = freshnessConfig ?: FreshnessConfig()
+        val validator = createFreshnessValidator(freshness)
         val bookkeeper = createBookkeeper()
 
         @Suppress("UNCHECKED_CAST")
@@ -76,6 +77,7 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
             bookkeeper = bookkeeper,
             validator = validator as FreshnessValidator<K, Any?>,
             memory = cache,
+            staleErrorDuration = freshness.staleIfError,
             scope = actualScope,
             timeSource = timeSource
         )
@@ -108,8 +110,7 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
         return SimpleConverterAdapter(IdentityConverter<K, V>())
     }
 
-    private fun createFreshnessValidator(): FreshnessValidator<K, DefaultDbMeta> {
-        val config = freshnessConfig ?: FreshnessConfig()
+    private fun createFreshnessValidator(config: FreshnessConfig): FreshnessValidator<K, DefaultDbMeta> {
         return DefaultFreshnessValidator(
             ttl = config.ttl
         )

--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
@@ -14,15 +14,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Instant
+import kotlin.time.Duration
 
 /**
  * Read-only store implementation.
@@ -61,6 +63,7 @@ class RealReadStore<
     private val bookkeeper: Bookkeeper<Key>,
     private val validator: FreshnessValidator<Key, Any?>,
     private val memory: MemoryCache<Key, Domain>,
+    private val staleErrorDuration: Duration? = null,
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     private val timeSource: TimeSource = TimeSource.SYSTEM
 ) : Store<Key, Domain>, AutoCloseable {
@@ -84,13 +87,22 @@ class RealReadStore<
         val dbMeta = initialDb?.let { converter.dbMetaFromProjection(it) }
         val status = bookkeeper.lastStatus(key)
         val plan = validator.plan(FreshnessContext(key, now(), freshness, dbMeta, status))
+        val latestMeta = MutableStateFlow<Any?>(dbMeta)
+
+        fun canServeStaleNow(): Boolean {
+            val window = staleErrorDuration ?: return true
+            val meta = latestMeta.value?.extractUpdatedAt()
+                ?: bookkeeper.lastStatus(key).lastSuccessAt
+                ?: return false
+            return (now() - meta) <= window
+        }
 
         // 3. Execute fetch if needed
         when (freshness) {
             Freshness.MustBeFresh -> {
                 if (plan !is FetchPlan.Skip) {
                     try {
-                        runBlockingFetch(key, plan, errorEvents)
+                        runBlockingFetch(key, plan)
                     } catch (e: kotlinx.coroutines.CancellationException) {
                         throw e
                     } catch (t: Throwable) {
@@ -102,11 +114,12 @@ class RealReadStore<
             else -> if (plan !is FetchPlan.Skip) {
                 launch {
                     try {
-                        runBlockingFetch(key, plan, errorEvents)
+                        runBlockingFetch(key, plan)
                     } catch (e: kotlinx.coroutines.CancellationException) {
                         throw e
                     } catch (t: Throwable) {
-                        errorEvents.send(StoreResult.Error(t, servedStale = true))
+                        val servedStale = canServeStaleNow()
+                        errorEvents.send(StoreResult.Error(t, servedStale = servedStale))
                     }
                 }
             }
@@ -122,6 +135,7 @@ class RealReadStore<
                 val meta = converter.dbMetaFromProjection(dbValue)
                 val updatedAt = meta.extractUpdatedAt() ?: Instant.fromEpochMilliseconds(0)
                 val age = now() - updatedAt
+                latestMeta.value = meta
                 memory.put(key, domain)
                 send(StoreResult.Data(domain, origin = Origin.SOT, age = age))
             }
@@ -172,7 +186,7 @@ class RealReadStore<
         storeScope.cancel()
     }
 
-    private suspend fun runBlockingFetch(key: Key, plan: FetchPlan, errorEvents: Channel<StoreResult.Error>) {
+    private suspend fun runBlockingFetch(key: Key, plan: FetchPlan) {
         fetchSingleFlight.launch(storeScope, key) {
             val req = when (plan) {
                 is FetchPlan.Conditional -> FetchRequest(conditional = plan.request)


### PR DESCRIPTION
## Summary
- plumb the freshness DSL's stale-if-error duration into RealReadStore
- gate stale fallback errors behind the configured window and reuse SoT metadata to compute age
- add a regression test exercising the stale window behaviour

## Testing
- Unable to run `./gradlew test` (requires JDK 17 toolchain in the container)

------
https://chatgpt.com/codex/tasks/task_e_68ea3a5a1d38832b869e7b251bdb256f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces the configured stale-if-error window in RealReadStore using SoT/bookkeeper metadata, wires freshness config from builder, and adds a regression test.
> 
> - **Core**:
>   - `RealReadStore`:
>     - Add `staleErrorDuration` and gate stale fallback errors via window using latest SoT meta or last success time.
>     - Track latest meta via `MutableStateFlow` and compute `servedStale` accordingly.
>     - Simplify `runBlockingFetch` signature (remove `errorEvents` param) and update callers.
>   - `DefaultStoreBuilderScope`:
>     - Plumb `FreshnessConfig` through builder, passing to `DefaultFreshnessValidator` and `RealReadStore` (`staleErrorDuration`).
> - **Tests**:
>   - Add test verifying non-stale error when stale-if-error window is exceeded.
>   - Test helper updated to pass `staleIfError` to `RealReadStore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92a168c7c06fb3f5d3261717c652c3501fe6222c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->