### PR TITLE
Fix stale flag when fetch fails without cache

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
@@ -79,6 +79,7 @@ class RealReadStore<
         } catch (e: Exception) {
             null
         }
+        val hadCachedData = initialDb != null
 
         // 2. Determine if we need to fetch
         val dbMeta = initialDb?.let { converter.dbMetaFromProjection(it) }
@@ -106,7 +107,7 @@ class RealReadStore<
                     } catch (e: kotlinx.coroutines.CancellationException) {
                         throw e
                     } catch (t: Throwable) {
-                        errorEvents.send(StoreResult.Error(t, servedStale = true))
+                        errorEvents.send(StoreResult.Error(t, servedStale = hadCachedData))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- ensure background fetch errors only report servedStale when cached data was available
- add regression coverage so Store.get propagates StoreException for CachedOrFetch failures without cache

## Testing
- `./gradlew test` *(fails: requires Java 17 toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea3a5a1d38832b869e7b251bdb256f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure background fetch errors only mark servedStale when cached data existed; add tests including Store.get propagation for CachedOrFetch without cache.
> 
> - **Core**:
>   - In `RealReadStore.stream(...)`, set `servedStale` based on presence of cached data (`hadCachedData`) when background fetch fails (non-`MustBeFresh`).
> - **Tests**:
>   - Update `stream_givenFetchError_thenEmitsError` to expect `servedStale == false` without cache.
>   - Add `get_cachedOrFetch_givenFetchErrorWithoutCache_thenPropagatesStoreException` asserting `Store.get(..., CachedOrFetch)` throws `StoreException.Unknown` when fetch fails and no cache.
>   - Keep `MustBeFresh` path emitting non-stale error as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa5c59a048896f8d08d192b1f8087d135b04d10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->