### PR TITLE
Add stale-if-error window handling to store builder

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
@@ -68,7 +68,8 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
         val cache = createMemoryCache()
         val sot = createSourceOfTruth()
         val converter = createConverter()
-        val validator = createFreshnessValidator()
+        val freshness = freshnessConfig ?: FreshnessConfig()
+        val validator = createFreshnessValidator(freshness)
         val bookkeeper = createBookkeeper()
 
         @Suppress("UNCHECKED_CAST")
@@ -78,6 +79,7 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
             converter = converter as Converter<K, V, V, V, V>,
             bookkeeper = bookkeeper,
             validator = validator as FreshnessValidator<K, Any?>,
+            staleIfErrorWindow = freshness.staleIfError,
             memory = cache,
             scope = actualScope,
             timeSource = timeSource
@@ -111,8 +113,7 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
         return SimpleConverterAdapter(IdentityConverter<K, V>())
     }
 
-    private fun createFreshnessValidator(): FreshnessValidator<K, DefaultDbMeta> {
-        val config = freshnessConfig ?: FreshnessConfig()
+    private fun createFreshnessValidator(config: FreshnessConfig): FreshnessValidator<K, DefaultDbMeta> {
         return DefaultFreshnessValidator(
             ttl = config.ttl
         )


### PR DESCRIPTION
## Summary
- teach `RealReadStore` to respect the DSL-configured `staleIfError` window when emitting errors
- pass the configured window through the store builder to the store implementation
- add regression tests covering stale-if-error behavior with and without a configured window

## Testing
- ./gradlew core:commonTest *(fails: missing Java 17 toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea44661f64832b9a6956e11b2ca0ea

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Plumbs a configurable stale-if-error window from the DSL to RealReadStore and uses it to decide when errors are marked as servedStale; adds targeted tests.
> 
> - **Core**
>   - `RealReadStore`: add `staleIfErrorWindow` parameter and `shouldServeStaleOnError` to compute `servedStale` based on `Freshness` and optional window; route errors through this logic.
> - **DSL/Builder**
>   - Pass `FreshnessConfig` through: use configured `staleIfError` and `ttl` by injecting into `DefaultFreshnessValidator` and wiring `staleIfError` into `RealReadStore`.
>   - Refactor `createFreshnessValidator(config)` signature.
> - **Tests**
>   - Add tests validating stale-if-error behavior with a window and with default (no window).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b212b267d3b30773eff551294694d5433bdba6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->