### PR TITLE
Add stale-if-error window handling to RealReadStore fallback

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
@@ -113,10 +113,17 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
 
     private fun createFreshnessValidator(): FreshnessValidator<K, DefaultDbMeta> {
         val config = freshnessConfig ?: FreshnessConfig()
-        return DefaultFreshnessValidator(
-            ttl = config.ttl,
-            staleIfErrorDuration = config.staleIfError
-        )
+        val staleIfError = config.staleIfError
+        return if (staleIfError != null) {
+            DefaultFreshnessValidator(
+                ttl = config.ttl,
+                staleIfErrorDuration = staleIfError
+            )
+        } else {
+            DefaultFreshnessValidator(
+                ttl = config.ttl
+            )
+        }
     }
 
     private fun createBookkeeper(): Bookkeeper<K> {

--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/dsl/internal/DefaultStoreBuilderScope.kt
@@ -114,7 +114,8 @@ internal class DefaultStoreBuilderScope<K : StoreKey, V : Any> : StoreBuilderSco
     private fun createFreshnessValidator(): FreshnessValidator<K, DefaultDbMeta> {
         val config = freshnessConfig ?: FreshnessConfig()
         return DefaultFreshnessValidator(
-            ttl = config.ttl
+            ttl = config.ttl,
+            staleIfErrorDuration = config.staleIfError
         )
     }
 

--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/FreshnessValidator.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/FreshnessValidator.kt
@@ -55,7 +55,7 @@ fun interface FreshnessValidator<K : StoreKey, DbMeta> {
  */
 interface StaleIfErrorPolicy {
     /** Duration window during which stale data can be served when fetch fails. */
-    val staleIfErrorDuration: Duration?
+    val staleIfErrorDuration: Duration
 }
 
 /**
@@ -70,11 +70,12 @@ data class DefaultDbMeta(
  * Default freshness validator using TTL-based caching.
  *
  * @param ttl Time-to-live for cached data (e.g., 5.minutes)
- * @param staleIfErrorDuration Duration window to allow serving stale data on error (default: 10.minutes)
+ * @param staleIfErrorDuration Duration window to allow serving stale data on error (default: 10.minutes).
+ * Pass [Duration.ZERO] to disable stale-on-error behavior.
  */
 class DefaultFreshnessValidator<K : StoreKey>(
     private val ttl: Duration,
-    override val staleIfErrorDuration: Duration? = 10.minutes,
+    override val staleIfErrorDuration: Duration = 10.minutes,
 ) : FreshnessValidator<K, DefaultDbMeta>, StaleIfErrorPolicy {
 
     override fun plan(ctx: FreshnessContext<K, DefaultDbMeta>): FetchPlan {

--- a/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
+++ b/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
@@ -191,11 +191,11 @@ class RealReadStoreTest {
             timeSource = timeSource
         )
 
-        val lastSuccessInsideWindow = currentTime - (staleWindow / 2)
+        val lastSuccessWithinWindow = currentTime - (staleWindow / 2)
         bookkeeper.setStatus(
             TEST_KEY_1,
             KeyStatus(
-                lastSuccessAt = lastSuccessInsideWindow,
+                lastSuccessAt = lastSuccessWithinWindow,
                 lastFailureAt = null,
                 lastEtag = null,
                 backoffUntil = null
@@ -214,11 +214,11 @@ class RealReadStoreTest {
         }
 
         // Advance time beyond the stale window and ensure stale data is not served
-        currentTime = lastSuccessInsideWindow + staleWindow + 1.minutes
+        currentTime = lastSuccessWithinWindow + staleWindow + 1.minutes
         bookkeeper.setStatus(
             TEST_KEY_1,
             KeyStatus(
-                lastSuccessAt = lastSuccessInsideWindow,
+                lastSuccessAt = lastSuccessWithinWindow,
                 lastFailureAt = null,
                 lastEtag = null,
                 backoffUntil = null


### PR DESCRIPTION
## Summary
- expose stale-if-error duration from the default freshness validator and pass it through the builder
- update RealReadStore to respect the stale window when deciding whether to serve cached data on fetch errors
- add a regression test exercising the fallback using a FakeBookkeeper-controlled last success timestamp

## Testing
- `./gradlew core:commonTest --tests dev.mattramotar.storex.core.internal.RealReadStoreTest.stream_staleIfError_respectsBookkeeperStaleWindowWhenMetaMissing` *(fails: requires JDK 17 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68ea44646e54832bb5c879cfb180f3aa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose a configurable stale-if-error window via DefaultFreshnessValidator and enforce it in RealReadStore when deciding if cached data is served on fetch errors; add a targeted test.
> 
> - **Core/Internal**:
>   - **Freshness policy**: Introduce `StaleIfErrorPolicy` exposing `staleIfErrorDuration`; make `DefaultFreshnessValidator` implement it with a default of `10.minutes`.
>   - **Builder**: Wire `FreshnessConfig.staleIfError` through `DefaultStoreBuilderScope` to `DefaultFreshnessValidator` (`staleIfErrorDuration`).
> - **Runtime behavior**:
>   - **RealReadStore**: On fetch errors, compute `servedStale` via a new `shouldServeStale` helper that respects the stale window (from `StaleIfErrorPolicy`), using `dbMeta.updatedAt` or `Bookkeeper.lastSuccessAt` as reference.
> - **Tests**:
>   - Add `stream_staleIfError_respectsBookkeeperStaleWindowWhenMetaMissing` to verify serving stale only within the configured window.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b994c831e9c38ce1ad75bf731478cc649ac2b2c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->