### PR TITLE
Fix RealReadStore error handling for non-cached fetch failures

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
@@ -91,6 +91,7 @@ class RealReadStore<
         val latestMeta = MutableStateFlow<Any?>(dbMeta)
 
         fun canServeStaleNow(): Boolean {
+            if (!hadCachedData) return false
             val window = staleErrorDuration ?: return true
             val meta = latestMeta.value?.extractUpdatedAt()
                 ?: bookkeeper.lastStatus(key).lastSuccessAt

--- a/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
+++ b/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
@@ -107,7 +107,7 @@ class RealReadStoreTest {
         // Given
         val fetcher = FakeFetcher<StoreKey, TestUser>()
         fetcher.respondWithError(TEST_KEY_1, TestNetworkException())
-        val store = createStore(scope = backgroundScope, fetcher = fetcher)
+        val store = createStore(fetcher = fetcher)
 
         // When/Then
         store.stream(TEST_KEY_1).test {
@@ -280,7 +280,7 @@ class RealReadStoreTest {
         val fetcher = FakeFetcher<StoreKey, TestUser>()
         val networkError = TestNetworkException("Network error")
         fetcher.respondWithError(TEST_KEY_1, networkError)
-        val store = createStore(scope = backgroundScope, fetcher = fetcher)
+        val store = createStore(fetcher = fetcher)
 
         // When/Then
         val thrown = assertFailsWith<StoreException> {


### PR DESCRIPTION
## Summary

Fixes two failing tests in `RealReadStoreTest`:
- `stream_givenFetchError_thenEmitsError` - AssertionError at line 118 (expected `servedStale=false` but got `true`)
- `get_cachedOrFetch_givenFetchErrorWithoutCache_thenPropagatesStoreException` - UncompletedCoroutinesError

**Root cause:** `canServeStaleNow()` was returning `true` when `staleErrorDuration=null`, even when there was no cached data available to serve stale. This caused errors from fetch failures without cache to be incorrectly marked as `servedStale=true`.

**Changes:**
- Added `hadCachedData` check in `canServeStaleNow()` in RealReadStore.kt:94 to return `false` when no cached data exists
- Removed `backgroundScope` parameter from two failing tests (default scope works correctly with `runTest`)

The fix ensures that when a fetch fails without cached data, the error is correctly marked as `servedStale=false`.

## Test plan

- [x] Fixed tests now pass locally (130 JVM tests passing)
- [x] No other tests broken by the change
- [x] Verified behavior: errors without cache → `servedStale=false`, errors with cache → depends on stale window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure fetch errors without cached data are not treated as stale; update tests to use default scope.
> 
> - **Core**:
>   - `RealReadStore.canServeStaleNow()` now returns `false` when no cached data exists, preventing `servedStale=true` on fetch failures without cache.
> - **Tests**:
>   - Use default scope in `stream_givenFetchError_thenEmitsError` and `get_cachedOrFetch_givenFetchErrorWithoutCache_thenPropagatesStoreException` (removed `backgroundScope` arg).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196291fd2cdad4b98d4ee8588bbdd3f01f49bcfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->