### PR TITLE
STOREX-1: Implement invalidation/clear runtime semantics

### DIFF
--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/MemoryCache.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/MemoryCache.kt
@@ -45,6 +45,11 @@ interface MemoryCache<Key: Any, Value: Any> {
      * Clears all entries from the cache.
      */
     suspend fun clear()
+
+    /**
+     * Returns a snapshot of keys currently held in memory.
+     */
+    suspend fun keys(): Set<Key>
 }
 
 /**
@@ -123,6 +128,10 @@ internal class MemoryCacheImpl<Key : Any, Value : Any>(
     override suspend fun clear() = mutex.withLock {
         cache.clear()
         accessOrder.clear()
+    }
+
+    override suspend fun keys(): Set<Key> = mutex.withLock {
+        cache.keys.toSet()
     }
 
     private fun isExpired(entry: CacheEntry<Value>): Boolean {

--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/RealReadStore.kt
@@ -16,12 +16,15 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
@@ -71,9 +74,17 @@ class RealReadStore<
     private val storeScope = scope
     private val fetchSingleFlight = SingleFlight<Key, Unit>()
     private val perKeyMutex = KeyMutex<Key>()
+    private val knownKeys = LinkedHashSet<Key>()
+    private val knownKeysMutex = Mutex()
+    private val invalidationSignals = MutableSharedFlow<InvalidationSignal<Key>>(
+        replay = 0,
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     private fun now(): Instant = timeSource.now()
 
     override fun stream(key: Key, freshness: Freshness): Flow<StoreResult<Domain>> = channelFlow {
+        rememberKey(key)
         val errorEvents = Channel<StoreResult.Error>(capacity = Channel.BUFFERED)
 
         // 1. Read from SoT to check if we have data
@@ -82,7 +93,7 @@ class RealReadStore<
         } catch (e: Exception) {
             null
         }
-        val hadCachedData = initialDb != null
+        val hasCachedData = MutableStateFlow(initialDb != null)
 
         // 2. Determine if we need to fetch
         val dbMeta = initialDb?.let { converter.dbMetaFromProjection(it) }
@@ -91,7 +102,7 @@ class RealReadStore<
         val latestMeta = MutableStateFlow<Any?>(dbMeta)
 
         fun canServeStaleNow(): Boolean {
-            if (!hadCachedData) return false
+            if (!hasCachedData.value) return false
             val window = staleErrorDuration ?: return true
             val meta = latestMeta.value?.extractUpdatedAt()
                 ?: bookkeeper.lastStatus(key).lastSuccessAt
@@ -138,8 +149,30 @@ class RealReadStore<
                 val updatedAt = meta.extractUpdatedAt() ?: Instant.fromEpochMilliseconds(0)
                 val age = now() - updatedAt
                 latestMeta.value = meta
+                hasCachedData.value = true
                 memory.put(key, domain)
                 send(StoreResult.Data(domain, origin = Origin.SOT, age = age))
+            }
+        }
+
+        launch {
+            invalidationSignals.collect { signal ->
+                if (!signal.matches(key)) return@collect
+
+                if (signal.destructive) {
+                    hasCachedData.value = false
+                    latestMeta.value = null
+                    send(StoreResult.Loading(fromCache = false))
+                }
+
+                try {
+                    runBlockingFetch(key, FetchPlan.Unconditional)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (t: Throwable) {
+                    val servedStale = !signal.destructive && canServeStaleNow()
+                    errorEvents.send(StoreResult.Error(t, servedStale = servedStale))
+                }
             }
         }
 
@@ -167,41 +200,69 @@ class RealReadStore<
 
     override fun invalidate(key: Key) {
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            rememberKey(key)
             memory.remove(key)
             sot.clearCache(key)
-            sot.delete(key)
+            invalidationSignals.tryEmit(InvalidationSignal(key = key, destructive = false))
         }
     }
 
     override fun invalidateNamespace(ns: StoreNamespace) {
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-            memory.clear()
+            val keys = keysInNamespace(ns)
+            keys.forEach { key ->
+                memory.remove(key)
+                sot.clearCache(key)
+            }
+            invalidationSignals.tryEmit(InvalidationSignal(namespace = ns, destructive = false))
         }
     }
 
     override fun invalidateAll() {
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            val keys = keysForMaintenance()
             memory.clear()
+            keys.forEach { key ->
+                sot.clearCache(key)
+            }
+            invalidationSignals.tryEmit(InvalidationSignal(all = true, destructive = false))
         }
     }
 
     override fun clear(key: Key) {
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            rememberKey(key)
             memory.remove(key)
             sot.clearCache(key)
             sot.delete(key)
+            forgetKey(key)
+            invalidationSignals.tryEmit(InvalidationSignal(key = key, destructive = true))
         }
     }
 
     override fun clearNamespace(ns: StoreNamespace) {
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-            memory.clear()
+            val keys = keysInNamespace(ns)
+            keys.forEach { key ->
+                memory.remove(key)
+                sot.clearCache(key)
+                sot.delete(key)
+                forgetKey(key)
+            }
+            invalidationSignals.tryEmit(InvalidationSignal(namespace = ns, destructive = true))
         }
     }
 
     override fun clearAll() {
         storeScope.launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            val keys = keysForMaintenance()
             memory.clear()
+            keys.forEach { key ->
+                sot.clearCache(key)
+                sot.delete(key)
+            }
+            clearKnownKeys()
+            invalidationSignals.tryEmit(InvalidationSignal(all = true, destructive = true))
         }
     }
 
@@ -210,6 +271,7 @@ class RealReadStore<
     }
 
     private suspend fun runBlockingFetch(key: Key, plan: FetchPlan) {
+        rememberKey(key)
         fetchSingleFlight.launch(storeScope, key) {
             val req = when (plan) {
                 is FetchPlan.Conditional -> FetchRequest(conditional = plan.request)
@@ -238,6 +300,45 @@ class RealReadStore<
                 }
             }
         }.await()
+    }
+
+    private suspend fun rememberKey(key: Key) {
+        knownKeysMutex.withLock {
+            knownKeys.add(key)
+        }
+    }
+
+    private suspend fun forgetKey(key: Key) {
+        knownKeysMutex.withLock {
+            knownKeys.remove(key)
+        }
+    }
+
+    private suspend fun clearKnownKeys() {
+        knownKeysMutex.withLock {
+            knownKeys.clear()
+        }
+    }
+
+    private suspend fun keysForMaintenance(): List<Key> {
+        val memoryKeys = memory.keys()
+        val known = knownKeysMutex.withLock { knownKeys.toSet() }
+        return (known + memoryKeys).toList()
+    }
+
+    private suspend fun keysInNamespace(namespace: StoreNamespace): List<Key> {
+        return keysForMaintenance().filter { key -> key.namespace == namespace }
+    }
+}
+
+private data class InvalidationSignal<Key : StoreKey>(
+    val key: Key? = null,
+    val namespace: StoreNamespace? = null,
+    val all: Boolean = false,
+    val destructive: Boolean
+) {
+    fun matches(target: Key): Boolean {
+        return all || key == target || namespace == target.namespace
     }
 }
 

--- a/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/SourceOfTruth.kt
+++ b/core/src/commonMain/kotlin/dev/mattramotar/storex/core/internal/SourceOfTruth.kt
@@ -184,7 +184,8 @@ interface SourceOfTruth<K : StoreKey, ReadDb, WriteDb> {
      * - Clear any in-memory cached state
      * - NOT delete persisted data (use [delete] for that)
      *
-     * Used by Store.invalidate() to force a fresh fetch on next read.
+     * Used by `Store.invalidate*()` to force a fresh fetch on next read.
+     * Destructive `Store.clear*()` operations call both `clearCache()` and `delete()`.
      *
      * Default implementation does nothing. Override to support cache invalidation.
      *

--- a/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
+++ b/core/src/commonTest/kotlin/internal/RealReadStoreTest.kt
@@ -10,6 +10,7 @@ import dev.mattramotar.storex.core.TimeSource
 import dev.mattramotar.storex.core.utils.FakeBookkeeper
 import dev.mattramotar.storex.core.utils.FakeFetcher
 import dev.mattramotar.storex.core.utils.FakeSourceOfTruth
+import dev.mattramotar.storex.core.utils.ARTICLE_KEY_1
 import dev.mattramotar.storex.core.utils.TEST_KEY_1
 import dev.mattramotar.storex.core.utils.TEST_KEY_2
 import dev.mattramotar.storex.core.utils.TEST_USER_1
@@ -306,7 +307,7 @@ class RealReadStoreTest {
     }
 
     @Test
-    fun invalidate_givenKey_thenDeletesFromSOT() = runTest {
+    fun invalidate_givenKey_thenDoesNotDeleteFromSOT() = runTest {
         // Given
         val sot = FakeSourceOfTruth<StoreKey, TestUser>()
         sot.emit(TEST_KEY_1, TEST_USER_1)
@@ -318,40 +319,88 @@ class RealReadStoreTest {
         store.invalidate(TEST_KEY_1)
         advanceUntilIdle()
 
-        // Then - memory cleared
+        // Then
         assertNull(memory.get(TEST_KEY_1))
-        // And SoT data deleted
+        assertTrue(sot.deletes.isEmpty())
+        assertEquals(TEST_USER_1, sot.getData(TEST_KEY_1))
+    }
+
+    @Test
+    fun clear_givenKey_thenDeletesFromSOT() = runTest {
+        // Given
+        val sot = FakeSourceOfTruth<StoreKey, TestUser>()
+        sot.emit(TEST_KEY_1, TEST_USER_1)
+        val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)
+        memory.put(TEST_KEY_1, TEST_USER_1)
+        val store = createStore(scope = backgroundScope, memory = memory, sot = sot)
+
+        // When
+        store.clear(TEST_KEY_1)
+        advanceUntilIdle()
+
+        // Then
+        assertNull(memory.get(TEST_KEY_1))
         assertEquals(1, sot.deletes.size)
         assertEquals(TEST_KEY_1, sot.deletes.first())
-        // Verify data is actually gone from SoT
         assertNull(sot.getData(TEST_KEY_1))
     }
 
     @Test
-    fun invalidateNamespace_thenClearsMemory() = runTest {
+    fun invalidateNamespace_thenClearsOnlyMatchingNamespaceMemory() = runTest {
         // Given
         val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)
         memory.put(TEST_KEY_1, TEST_USER_1)
         memory.put(TEST_KEY_2, TEST_USER_2)
+        memory.put(ARTICLE_KEY_1, TEST_USER_1)
         val store = createStore(scope = backgroundScope, memory = memory)
 
         // When
         store.invalidateNamespace(TEST_KEY_1.namespace)
-        delay(1)  // Yield to allow launched coroutine to run
+        delay(1)
         advanceUntilIdle()
 
         // Then
         assertNull(memory.get(TEST_KEY_1))
         assertNull(memory.get(TEST_KEY_2))
+        assertEquals(TEST_USER_1, memory.get(ARTICLE_KEY_1))
     }
 
     @Test
-    fun invalidateAll_thenClearsMemory() = runTest {
+    fun clearNamespace_thenDeletesMatchingNamespaceData() = runTest {
         // Given
+        val sot = FakeSourceOfTruth<StoreKey, TestUser>()
+        sot.emit(TEST_KEY_1, TEST_USER_1)
+        sot.emit(TEST_KEY_2, TEST_USER_2)
+        sot.emit(ARTICLE_KEY_1, TEST_USER_1)
         val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)
         memory.put(TEST_KEY_1, TEST_USER_1)
         memory.put(TEST_KEY_2, TEST_USER_2)
-        val store = createStore(scope = backgroundScope, memory = memory)
+        memory.put(ARTICLE_KEY_1, TEST_USER_1)
+        val store = createStore(scope = backgroundScope, memory = memory, sot = sot)
+
+        // When
+        store.clearNamespace(TEST_KEY_1.namespace)
+        advanceUntilIdle()
+
+        // Then
+        assertNull(memory.get(TEST_KEY_1))
+        assertNull(memory.get(TEST_KEY_2))
+        assertEquals(TEST_USER_1, memory.get(ARTICLE_KEY_1))
+        assertNull(sot.getData(TEST_KEY_1))
+        assertNull(sot.getData(TEST_KEY_2))
+        assertEquals(TEST_USER_1, sot.getData(ARTICLE_KEY_1))
+    }
+
+    @Test
+    fun invalidateAll_thenClearsMemoryWithoutDeletingSot() = runTest {
+        // Given
+        val sot = FakeSourceOfTruth<StoreKey, TestUser>()
+        sot.emit(TEST_KEY_1, TEST_USER_1)
+        sot.emit(TEST_KEY_2, TEST_USER_2)
+        val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)
+        memory.put(TEST_KEY_1, TEST_USER_1)
+        memory.put(TEST_KEY_2, TEST_USER_2)
+        val store = createStore(scope = backgroundScope, memory = memory, sot = sot)
 
         // When
         store.invalidateAll()
@@ -360,6 +409,30 @@ class RealReadStoreTest {
         // Then
         assertNull(memory.get(TEST_KEY_1))
         assertNull(memory.get(TEST_KEY_2))
+        assertEquals(TEST_USER_1, sot.getData(TEST_KEY_1))
+        assertEquals(TEST_USER_2, sot.getData(TEST_KEY_2))
+    }
+
+    @Test
+    fun clearAll_thenClearsMemoryAndDeletesSot() = runTest {
+        // Given
+        val sot = FakeSourceOfTruth<StoreKey, TestUser>()
+        sot.emit(TEST_KEY_1, TEST_USER_1)
+        sot.emit(TEST_KEY_2, TEST_USER_2)
+        val memory = MemoryCacheImpl<StoreKey, TestUser>(maxSize = 100, ttl = 10.minutes, timeSource = TimeSource.SYSTEM)
+        memory.put(TEST_KEY_1, TEST_USER_1)
+        memory.put(TEST_KEY_2, TEST_USER_2)
+        val store = createStore(scope = backgroundScope, memory = memory, sot = sot)
+
+        // When
+        store.clearAll()
+        advanceUntilIdle()
+
+        // Then
+        assertNull(memory.get(TEST_KEY_1))
+        assertNull(memory.get(TEST_KEY_2))
+        assertNull(sot.getData(TEST_KEY_1))
+        assertNull(sot.getData(TEST_KEY_2))
     }
 
     @Test

--- a/mutations/src/commonMain/kotlin/dev/mattramotar/storex/mutations/dsl/internal/DefaultMutationStoreBuilderScope.kt
+++ b/mutations/src/commonMain/kotlin/dev/mattramotar/storex/mutations/dsl/internal/DefaultMutationStoreBuilderScope.kt
@@ -357,4 +357,8 @@ private class InMemoryCache<K : Any, V : Any>(
     override suspend fun clear() {
         cache.clear()
     }
+
+    override suspend fun keys(): Set<K> {
+        return cache.keys.toSet()
+    }
 }

--- a/mutations/src/commonMain/kotlin/dev/mattramotar/storex/mutations/internal/RealMutationStore.kt
+++ b/mutations/src/commonMain/kotlin/dev/mattramotar/storex/mutations/internal/RealMutationStore.kt
@@ -40,12 +40,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -142,8 +146,16 @@ class RealMutationStore<
     private val storeScope = scope
     private val fetchSingleFlight = SingleFlight<Key, Unit>()
     private val perKeyMutex = KeyMutex<Key>()
+    private val knownKeys = LinkedHashSet<Key>()
+    private val knownKeysMutex = Mutex()
+    private val invalidationSignals = MutableSharedFlow<InvalidationSignal<Key>>(
+        replay = 0,
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
 
     override fun stream(key: Key, freshness: Freshness): Flow<StoreResult<Domain>> = channelFlow {
+        rememberKey(key)
         val errorEvents = Channel<StoreResult.Error>(capacity = Channel.BUFFERED)
 
         val initialDb: ReadEntity? = try {
@@ -151,12 +163,18 @@ class RealMutationStore<
         } catch (e: Exception) {
             null
         }
+        val hasCachedData = MutableStateFlow(initialDb != null)
         val dbMeta = initialDb?.let { converter.dbMetaFromProjection(it) }
         val status = bookkeeper.lastStatus(key)
         val plan = validator.plan(FreshnessContext(key, now(), freshness, dbMeta, status))
+        val latestMeta = MutableStateFlow<Any?>(dbMeta)
 
         suspend fun doFetch() {
             runBlockingFetch(key, plan, errorEvents)
+        }
+
+        fun canServeStaleNow(): Boolean {
+            return hasCachedData.value
         }
 
         when (freshness) {
@@ -181,12 +199,35 @@ class RealMutationStore<
                 val meta = converter.dbMetaFromProjection(dbValue)
                 val updatedAt = meta.extractUpdatedAt() ?: Instant.fromEpochMilliseconds(0)
                 val age = now() - updatedAt
+                latestMeta.value = meta
+                hasCachedData.value = true
                 memory.put(key, domain)
                 send(StoreResult.Data(domain, origin = Origin.SOT, age = age))
             }
         }
+
+        val invalidationJob = launch {
+            invalidationSignals.collect { signal ->
+                if (!signal.matches(key)) return@collect
+
+                if (signal.destructive) {
+                    latestMeta.value = null
+                    hasCachedData.value = false
+                    send(StoreResult.Loading(fromCache = false))
+                }
+
+                try {
+                    runBlockingFetch(key, FetchPlan.Unconditional, errorEvents)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (t: Throwable) {
+                    val servedStale = !signal.destructive && canServeStaleNow()
+                    errorEvents.trySend(StoreResult.Error(t, servedStale = servedStale))
+                }
+            }
+        }
         val errJob = launch { for (e in errorEvents) send(e) }
-        joinAll(sotJob, errJob)
+        joinAll(sotJob, errJob, invalidationJob)
     }
 
     override suspend fun get(key: Key, freshness: Freshness): Domain {
@@ -380,21 +421,78 @@ class RealMutationStore<
         }
     }
 
-    override fun invalidate(key: Key) { storeScope.launch { memory.remove(key) } }
-    override fun invalidateNamespace(ns: StoreNamespace) { storeScope.launch { memory.clear() } }
-    override fun invalidateAll() { storeScope.launch { memory.clear() } }
+    override fun invalidate(key: Key) {
+        storeScope.launch {
+            rememberKey(key)
+            memory.remove(key)
+            sot.clearCache(key)
+            invalidationSignals.tryEmit(InvalidationSignal(key = key, destructive = false))
+        }
+    }
+
+    override fun invalidateNamespace(ns: StoreNamespace) {
+        storeScope.launch {
+            val keys = keysInNamespace(ns)
+            keys.forEach { key ->
+                memory.remove(key)
+                sot.clearCache(key)
+            }
+            invalidationSignals.tryEmit(InvalidationSignal(namespace = ns, destructive = false))
+        }
+    }
+
+    override fun invalidateAll() {
+        storeScope.launch {
+            val keys = keysForMaintenance()
+            memory.clear()
+            keys.forEach { key ->
+                sot.clearCache(key)
+            }
+            invalidationSignals.tryEmit(InvalidationSignal(all = true, destructive = false))
+        }
+    }
+
     override fun clear(key: Key) {
         storeScope.launch {
+            rememberKey(key)
             memory.remove(key)
             sot.clearCache(key)
             sot.delete(key)
+            forgetKey(key)
+            invalidationSignals.tryEmit(InvalidationSignal(key = key, destructive = true))
         }
     }
-    override fun clearNamespace(ns: StoreNamespace) { storeScope.launch { memory.clear() } }
-    override fun clearAll() { storeScope.launch { memory.clear() } }
+
+    override fun clearNamespace(ns: StoreNamespace) {
+        storeScope.launch {
+            val keys = keysInNamespace(ns)
+            keys.forEach { key ->
+                memory.remove(key)
+                sot.clearCache(key)
+                sot.delete(key)
+                forgetKey(key)
+            }
+            invalidationSignals.tryEmit(InvalidationSignal(namespace = ns, destructive = true))
+        }
+    }
+
+    override fun clearAll() {
+        storeScope.launch {
+            val keys = keysForMaintenance()
+            memory.clear()
+            keys.forEach { key ->
+                sot.clearCache(key)
+                sot.delete(key)
+            }
+            clearKnownKeys()
+            invalidationSignals.tryEmit(InvalidationSignal(all = true, destructive = true))
+        }
+    }
+
     override fun close() { storeScope.cancel() }
 
     private suspend fun runBlockingFetch(key: Key, plan: FetchPlan, errorEvents: Channel<StoreResult.Error>) {
+        rememberKey(key)
         fetchSingleFlight.launch(storeScope, key) {
             try {
                 val req = when (plan) {
@@ -429,6 +527,34 @@ class RealMutationStore<
         }.await()
     }
 
+    private suspend fun rememberKey(key: Key) {
+        knownKeysMutex.withLock {
+            knownKeys.add(key)
+        }
+    }
+
+    private suspend fun forgetKey(key: Key) {
+        knownKeysMutex.withLock {
+            knownKeys.remove(key)
+        }
+    }
+
+    private suspend fun clearKnownKeys() {
+        knownKeysMutex.withLock {
+            knownKeys.clear()
+        }
+    }
+
+    private suspend fun keysForMaintenance(): List<Key> {
+        val memoryKeys = memory.keys()
+        val known = knownKeysMutex.withLock { knownKeys.toSet() }
+        return (known + memoryKeys).toList()
+    }
+
+    private suspend fun keysInNamespace(namespace: StoreNamespace): List<Key> {
+        return keysForMaintenance().filter { key -> key.namespace == namespace }
+    }
+
     private fun fakeKeyForCreate(): Key {
         @Suppress("UNCHECKED_CAST")
         return ByIdKey(
@@ -442,3 +568,14 @@ class RealMutationStore<
 
 /* helper to extract updatedAt from arbitrary meta objects */
 private fun Any?.extractUpdatedAt(): Instant? = this as? Instant
+
+private data class InvalidationSignal<Key : StoreKey>(
+    val key: Key? = null,
+    val namespace: StoreNamespace? = null,
+    val all: Boolean = false,
+    val destructive: Boolean
+) {
+    fun matches(target: Key): Boolean {
+        return all || key == target || namespace == target.namespace
+    }
+}


### PR DESCRIPTION
## Summary
- make invalidate operations non-destructive and emit refetch signals for active streams
- make clear operations destructive for key/namespace/all paths
- align mutation-store invalidation/clear behavior with read-core contract
- add key tracking and maintenance helpers for namespace/all operations

## Validation
- ./gradlew :core:jvmTest :mutations:jvmTest --stacktrace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core invalidation/clear behavior and introduces new async signaling/key-tracking, which could affect cache consistency and stream behavior under concurrency (including missed signals due to buffering). Test coverage is expanded, but the runtime semantics shift is significant.
> 
> **Overview**
> **Invalidation and clear semantics are redefined across read and mutation stores.** `invalidate*()` is now *non-destructive* (evicts memory + calls `SourceOfTruth.clearCache()` without deleting persisted rows), while `clear*()` remains *destructive* (also calls `SourceOfTruth.delete()`).
> 
> **Active `stream()` observers now react to invalidations by refetching.** Both `RealReadStore` and `RealMutationStore` add an internal `MutableSharedFlow` invalidation bus; destructive clears reset stream state to `Loading` before forcing an unconditional refetch.
> 
> **Namespace/all operations are no longer “clear everything”.** Stores track `knownKeys` and add `MemoryCache.keys()` so `invalidateNamespace`/`clearNamespace` and `invalidateAll`/`clearAll` operate over the relevant keys (and avoid touching unrelated namespaces). Tests are updated/added to assert the new non-destructive vs destructive behavior and namespace scoping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c48d14fe5328a6667077a5b06135dcda1a545299. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->