### PR TITLE
STOREX-1: Add full CI matrix and phase-1 architecture docs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,14 +9,9 @@ on:
       - main
 
 jobs:
-  build-and-test:
+  build-and-test-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        api-level:
-          - 29
     steps:
 
       - name: Checkout
@@ -47,3 +42,36 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/reports/kover/coverage.xml
           slug: matt-ramotar/storex
+
+  build-and-test-macos-ios:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Grant execute permission for Gradlew
+        run: chmod +x gradlew
+
+      - name: Run iOS Simulator Contract Suite
+        run: >
+          ./gradlew
+          :core:iosSimulatorArm64Test
+          :mutations:iosSimulatorArm64Test
+          :paging:iosSimulatorArm64Test
+          :resilience:iosSimulatorArm64Test
+          :normalization:runtime:iosSimulatorArm64Test
+          --stacktrace

--- a/docs/reviews/storex-store-distinguished-review-phase1.md
+++ b/docs/reviews/storex-store-distinguished-review-phase1.md
@@ -1,0 +1,36 @@
+# Store vs StoreX Phase 1 Review
+
+## Reviewer Lens
+Distinguished software engineering review for public API durability, migration risk, and developer adoption readiness.
+
+## Executive Summary
+StoreX Phase 1 now has a clearer read-core contract than the pre-freeze baseline, primarily due to the explicit non-destructive `invalidate*` vs destructive `clear*` split and new contract-focused test coverage.  
+Primary remaining risks are seam leaks (`core.internal`) in extension modules and inconsistent reactive SoT guarantees outside core.
+
+## Store vs StoreX Delta (Phase 1)
+| Area | Upstream Store (reference) | StoreX after Phase 1 | Risk |
+|---|---|---|---|
+| Read contracts | Mature read semantics and freshness story | Explicitly frozen in docs/tests | Low |
+| Invalidation semantics | Historically nuanced/implementation-sensitive | Now explicitly split: invalidate vs clear | Low |
+| Cross-target confidence | Mature CI history | Added Linux + macOS iOS-simulator lanes | Medium |
+| Extension seams | Established conceptually | Still partially coupled to internals | High |
+| Mutation/read parity | Cohesive but evolving | Read/Mutation invalidation semantics aligned | Medium |
+
+## What Improved in Phase 1
+- API contract drift reduced by introducing clear destructive methods.
+- Runtime now treats invalidation as stale-marking and refetch signaling.
+- Dedicated read-core contract suite added with platform wrappers.
+- CI now has explicit macOS iOS simulator validation lane.
+
+## Critical Follow-up Risks (Phase 2 candidates)
+1. `mutations` and `normalization` expose or rely on `core.internal`.
+2. Some SoT implementations in extension builders are one-shot and weaker than read-core reactive expectations.
+3. Namespace/all destructive operations are best-effort for unknown persisted keys unless SoT-specific enumeration/deletion hooks are provided.
+
+## Developer Experience Guidance
+- Keep docs explicit about `invalidate*` vs `clear*` semantics.
+- Keep examples extension-agnostic for read-core primitives.
+- Avoid promoting internal types in public snippets and typealiases.
+
+## Recommendation
+Proceed with Phase 1 closure and immediately prioritize seam extraction (`STOREX-2`) to prevent Phase 1 guarantees from being diluted by extension coupling.

--- a/docs/store6/extension-author-non-goals.md
+++ b/docs/store6/extension-author-non-goals.md
@@ -1,0 +1,24 @@
+# Extension Author Non-Goals (Phase 1)
+
+This document defines what extension authors should **not** depend on while StoreX remains in Phase 1.
+
+## Non-goals
+- Do not depend on `core.internal` implementation details for long-term compatibility.
+- Do not assume mutation queueing or replay guarantees from read-core primitives.
+- Do not assume read-core owns background sync lifecycle.
+- Do not assume normalization/paging internals are stable seams.
+- Do not couple extension behavior to current incidental stream timing details beyond documented `Store` contracts.
+
+## Required Boundaries
+- Depend on read-core public contracts only:
+  - `Store`
+  - `StoreKey`
+  - `Freshness`
+  - `StoreResult`
+- Treat `invalidate*` as stale-marking and `clear*` as destructive.
+- Keep extension-specific policies (paging windows, normalization reconciliation, retry internals) scoped to extension modules.
+
+## Deferred to Phase 2+
+- Formal seam package and lifecycle hooks (`STOREX-2`)
+- write/sync queueing contracts (`STOREX-3`)
+- normalization/paging composable hardening (`STOREX-4`)

--- a/docs/store6/read-core-stability-notes.md
+++ b/docs/store6/read-core-stability-notes.md
@@ -1,0 +1,43 @@
+# Store6 Read-Core Stability Notes (Phase 1)
+
+## Milestone
+- Linear issue: `STOREX-1`
+- Phase: `Phase 1 - Freeze Store6 Read Core`
+
+## Frozen Surface
+The following API surface is frozen for the first 6.0 alpha contract:
+- `Store.get`
+- `Store.stream`
+- `Store.invalidate`, `Store.invalidateNamespace`, `Store.invalidateAll`
+- `Store.clear`, `Store.clearNamespace`, `Store.clearAll`
+- `StoreKey` and `StoreNamespace`
+- `Freshness`
+- `StoreResult`
+
+## Semantic Guarantees
+- `invalidate*` is non-destructive:
+  - evicts memory
+  - clears SoT cache state
+  - does not delete persisted SoT data
+  - triggers refetch for active streams
+- `clear*` is destructive:
+  - evicts memory
+  - clears SoT cache state
+  - deletes persisted SoT data for impacted keys
+- `MustBeFresh` remains blocking and terminal on fetch failure.
+- `CachedOrFetch`, `MinAge`, and `StaleIfError` retain current runtime behavior.
+
+## Coverage/Validation Expectations
+- Read-core contract tests in `core/src/commonTest/kotlin/contract`.
+- Explicit target smoke wrappers in:
+  - `core/src/jvmTest/kotlin/contract`
+  - `core/src/jsTest/kotlin/contract`
+  - `core/src/nativeTest/kotlin/contract`
+- CI requires:
+  - Linux: `./gradlew clean build koverXmlReport --stacktrace`
+  - macOS: iOS simulator test lane for core + extension modules.
+
+## Known Limitations Carried Forward
+- Some extension modules still depend on `core.internal` and are addressed in `STOREX-2`.
+- `StoreResult.Loading(fromCache=true)` remains unexercised in read-core runtime.
+- Full upstream migration narrative remains phase-gated to `STOREX-5`.


### PR DESCRIPTION
## Summary
- add explicit Linux + macOS/iOS validation lanes in build-and-test workflow for full read-core target coverage
- publish Phase-1 read-core stability docs and extension non-goals
- add Distinguished Engineer review artifact with Store vs StoreX deltas and Phase-2 seam risks

## Validation
- ./gradlew clean build koverXmlReport --stacktrace
- GitHub Actions build-and-test workflow (linux + macOS/iOS lanes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI workflow and documentation updates; low risk to runtime behavior, but may increase CI time/flakiness due to added iOS simulator tests.
> 
> **Overview**
> Updates CI to split `build-and-test` into a Linux job (build/test + coverage upload) and a new macOS job that runs iOS Simulator tests across `core` and key extension modules.
> 
> Adds Phase 1 architecture/stability documentation that freezes the read-core public surface and explicitly defines `invalidate*` (non-destructive) vs `clear*` (destructive) semantics, plus guidance for extension authors and a Phase 1 review artifact highlighting remaining seam risks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 298b7e3cb7ceb7af40cd872f1c380d3cbe7ebfd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->